### PR TITLE
Rewrote plugin code to perform food.gov.uk request from addon script 

### DIFF
--- a/firefox/addon/data/api.js
+++ b/firefox/addon/data/api.js
@@ -179,80 +179,9 @@ restaurantEntries.each(function () {
 	
 	$(scorePlaceholder).attr("data-rating", 0);
 
-	$(scorePlaceholder).attr("data-nomorvom-id", restaurantId);
-
-	// Use this in future, but currently in for filtering
 	_this.attr("data-nomorvom-id", restaurantId);
 
     _this.append(scorePlaceholder);
     
     restaurantId++;
-
-/*
-    var rating = 0;
-
-    $.ajax({
-        url: url,
-        type: 'GET',
-        dataType: 'json',
-        cache: false,
-        success: function (data, status) {
-			if (data.establishments.length > 0) {
-				scorePlaceholder.removeChild(loadingText);
-				scorePlaceholder.removeChild(loaderImg);
-				rating = data.establishments[0].RatingValue;
-				for (var i = 0; i < rating; i++) {
-					AppendImg(scorePlaceholder, '48-fork-and-knife-icon.png');
-				}
-				for (var i = 0; i < 5 - rating; i++) {
-					AppendImg(scorePlaceholder, 'toilet-paper-icon_32.png');
-				}
-				var resultText = document.createElement('div');
-				resultText.id = "hygieneScore"
-				resultText.style.fontWeight = "bold";
-				resultText.style.margin = "0px 5px";
-
-
-				if (rating == "AwaitingInspection") {
-					$(resultText).text("This takeaway is awaiting inspection");					
-					rating = 0;
-				}	
-				else {
-					$(resultText).text("Hygiene Score : " + rating + "/5");
-				}
-				scorePlaceholder.appendChild(resultText);
-				
-				$(scorePlaceholder).attr("data-rating", rating);
-			}
-			else
-			{
-				scorePlaceholder.removeChild(loadingText);
-				scorePlaceholder.removeChild(loaderImg);
-				
-				var resultText = document.createElement('div');
-				resultText.id = "hygieneScore";
-				resultText.style.fontWeight = "bold";
-				resultText.style.margin = "5px 5px";
-				$(resultText).text("Sorry, no food hygiene data found");
-				
-				scorePlaceholder.appendChild(resultText);
-
-				$(scorePlaceholder).attr("data-rating", rating);
-			}
-			
-			var ratingFilterRange = $(scoreFilterSlider).slider("values");
-			//var excludeNoData =  $(excludeNoDataCheckbox).prop('checked');
-			//if ( ((rating == -1) && excludeNoData) || (rating < ratingFilterRange[0]) || (rating > ratingFilterRange[1]) ) { 
-			if ((rating < ratingFilterRange[0]) || (rating > ratingFilterRange[1])) { 
-				_this.hide();
-			}
-			else
-			{
-				_this.show();
-			}
-        },
-        error: function (error) { },
-        beforeSend: function (xhr) { xhr.setRequestHeader('x-api-version', 2); }
-    });
-*/
 });

--- a/firefox/addon/data/api.js
+++ b/firefox/addon/data/api.js
@@ -97,6 +97,9 @@ restaurantEntries.each(function () {
     	.end()
     	.text().trim();
 
+    self.port.emit("queryRestaurant", {name:name, address:address});
+
+
     var url = "http://api.ratings.food.gov.uk/Establishments?name=" + encodeURIComponent(name) + "&address=" + encodeURIComponent(address);
 
     var scorePlaceholder = document.createElement('div');

--- a/firefox/addon/data/api.js
+++ b/firefox/addon/data/api.js
@@ -89,7 +89,7 @@ $("div.restaurants").prepend(config);
 
 // Set up the listener for the result returned from the addon script
 self.port.on("restaurantScore", function(restaurantScore) {
-	console.log("id " + restaurantScore.id + ", rating " + restaurantScore.rating);
+	//console.log("id " + restaurantScore.id + ", rating " + restaurantScore.rating);
 	// find the score placeholder for the restaurant we've got a result for
 	var restaurantScorePlaceholder = $("div.restaurant[data-nomorvom-id='"+restaurantScore.id+"'] div#nomorvom");
 	restaurantScorePlaceholder.attr("data-rating", restaurantScore.rating);

--- a/firefox/addon/data/api.js
+++ b/firefox/addon/data/api.js
@@ -91,18 +91,20 @@ $("div.restaurants").prepend(config);
 self.port.on("restaurantScore", function(restaurantScore) {
 	console.log("id " + restaurantScore.id + ", rating " + restaurantScore.rating);
 	// find the score placeholder for the restaurant we've got a result for
-	var restaurantScorePlaceholder = $("div#nomorvom[data-nomorvom-id='"+restaurantScore.id+"']");
+	var restaurantScorePlaceholder = $("div.restaurant[data-nomorvom-id='"+restaurantScore.id+"'] div#nomorvom");
 	restaurantScorePlaceholder.attr("data-rating", restaurantScore.rating);
 	$("p#nomorvom_loading", restaurantScorePlaceholder).remove();
 	$("div#nomorvom_progressbar", restaurantScorePlaceholder).remove();
 	
-	for (var i = 0; i < restaurantScore.rating; i++) {
-		AppendImg(restaurantScorePlaceholder, '48-fork-and-knife-icon.png');
+	if (restaurantScore.rating > 0) {
+		for (var i = 0; i < restaurantScore.rating; i++) {
+			AppendImg(restaurantScorePlaceholder, '48-fork-and-knife-icon.png');
+		}
+		for (var i = 0; i < 5 - restaurantScore.rating; i++) {
+			AppendImg(restaurantScorePlaceholder, 'toilet-paper-icon_32.png');
+		}
 	}
-	for (var i = 0; i < 5 - restaurantScore.rating; i++) {
-		AppendImg(restaurantScorePlaceholder, 'toilet-paper-icon_32.png');
-	}
-	
+
 	var resultText = document.createElement('div');
 	resultText.id = "hygieneScore"
 	resultText.style.fontWeight = "bold";
@@ -113,9 +115,27 @@ self.port.on("restaurantScore", function(restaurantScore) {
 		restaurantScore.rating = 0;
 	}	
 	else {
-		$(resultText).text("Hygiene Score : " + restaurantScore.rating + "/5");
+		if (restaurantScore.rating == -1) {
+			$(resultText).text("Sorry, no food hygiene data found");
+		}
+		else {
+			$(resultText).text("Hygiene Score : " + restaurantScore.rating + "/5");
+		}
 	}
 	restaurantScorePlaceholder.append(resultText);
+
+	// Filter accordingly
+	var ratingFilterRange = $(scoreFilterSlider).slider("values");
+	//var excludeNoData =  $(excludeNoDataCheckbox).prop('checked');
+	//if ( ((rating == -1) && excludeNoData) || (rating < ratingFilterRange[0]) || (rating > ratingFilterRange[1]) ) { 
+	if ((restaurantScore.rating < ratingFilterRange[0]) || (restaurantScore.rating > ratingFilterRange[1])) { 
+		$("div.restaurant[data-nomorvom-id='"+restaurantScore.id+"']").hide();
+	}
+	else
+	{
+		$("div.restaurant[data-nomorvom-id='"+restaurantScore.id+"']").show();
+	}
+
 });
 
 
@@ -161,11 +181,12 @@ restaurantEntries.each(function () {
 
 	$(scorePlaceholder).attr("data-nomorvom-id", restaurantId);
 
+	// Use this in future, but currently in for filtering
+	_this.attr("data-nomorvom-id", restaurantId);
+
     _this.append(scorePlaceholder);
     
     restaurantId++;
-
-
 
 /*
     var rating = 0;

--- a/firefox/addon/lib/main.js
+++ b/firefox/addon/lib/main.js
@@ -3,9 +3,34 @@ var self = require("sdk/self");
 
 pageMod.PageMod({
     include: ["http://www.just-eat.co.uk/area/*", "http://just-eat.co.uk/area/*"],
-    //include: "http://localhost/*",
-	contentStyleFile: [self.data.url("jquery-ui-1.11.4/jquery-ui.min.css"), self.data.url("nomorvom.css")],
+ 	contentStyleFile: [self.data.url("jquery-ui-1.11.4/jquery-ui.min.css"), self.data.url("nomorvom.css")],
     contentScriptOptions: {prefixDataURI: self.data.url("")},
 	contentScriptFile: [self.data.url("jquery-2.1.3/jquery-2.1.3.min.js"), self.data.url("jquery-ui-1.11.4/jquery-ui.min.js"), self.data.url("api.js")],
-	contentScriptWhen: "ready"
+	contentScriptWhen: "ready",
+	onAttach: startListening
 });
+
+function startListening(worker) {
+	worker.port.on("queryRestaurant", function(restaurant) {
+		console.log(restaurant);
+		
+		var url = "http://api.ratings.food.gov.uk/Establishments?name=" + encodeURIComponent(restaurant.name) + "&address=" + encodeURIComponent(restaurant.address); 
+
+		var Request = require("sdk/request").Request;
+		var foodLookupRequest = Request({
+  			url: url,
+  			headers: {'x-api-version':2, 'Content-Type':'application/json', 'Accept':'application/json'},
+			onComplete: function (response) {	
+				console.log(response);
+				if (response.json != null) {
+					console.log(response.json.data.establishments.length);
+					if (response.json.data.establishments.length > 0) {
+						rating = response.json.data.establishments[0].RatingValue;
+						console.log(rating);
+					}
+				}
+				//worker.port.emit("restaurantScore", rating);
+			}
+		}).get();
+	});	
+}

--- a/firefox/addon/lib/main.js
+++ b/firefox/addon/lib/main.js
@@ -12,7 +12,7 @@ pageMod.PageMod({
 
 function startListening(worker) {
 	worker.port.on("queryRestaurant", function(restaurant) {
-		console.log(restaurant);
+		//console.log(restaurant);
 		
 		var url = "http://api.ratings.food.gov.uk/Establishments?name=" + encodeURIComponent(restaurant.name) + "&address=" + encodeURIComponent(restaurant.address); 
 		var rating = 0;
@@ -22,9 +22,7 @@ function startListening(worker) {
   			url: url,
   			headers: {'x-api-version':2, 'Content-Type':'application/json', 'Accept':'application/json'},
 			onComplete: function (response) {	
-				//console.log(response);
 				if (response.json != null) {
-					//console.log(response.json);
 					if (response.json.establishments.length > 0) {
 						rating = response.json.establishments[0].RatingValue;
 					} 

--- a/firefox/addon/lib/main.js
+++ b/firefox/addon/lib/main.js
@@ -15,21 +15,21 @@ function startListening(worker) {
 		console.log(restaurant);
 		
 		var url = "http://api.ratings.food.gov.uk/Establishments?name=" + encodeURIComponent(restaurant.name) + "&address=" + encodeURIComponent(restaurant.address); 
+		var rating = 0;
 
 		var Request = require("sdk/request").Request;
 		var foodLookupRequest = Request({
   			url: url,
   			headers: {'x-api-version':2, 'Content-Type':'application/json', 'Accept':'application/json'},
 			onComplete: function (response) {	
-				console.log(response);
+				//console.log(response);
 				if (response.json != null) {
-					console.log(response.json.data.establishments.length);
-					if (response.json.data.establishments.length > 0) {
-						rating = response.json.data.establishments[0].RatingValue;
-						console.log(rating);
+					//console.log(response.json);
+					if (response.json.establishments.length > 0) {
+						rating = response.json.establishments[0].RatingValue;
 					}
 				}
-				//worker.port.emit("restaurantScore", rating);
+				worker.port.emit("restaurantScore", {id:restaurant.id, rating:rating});
 			}
 		}).get();
 	});	

--- a/firefox/addon/lib/main.js
+++ b/firefox/addon/lib/main.js
@@ -2,7 +2,7 @@ var pageMod = require("sdk/page-mod");
 var self = require("sdk/self");
 
 pageMod.PageMod({
-    include: ["http://www.just-eat.co.uk/area/*", "http://just-eat.co.uk/area/*"],
+    include: ["http://www.just-eat.co.uk/area/*", "http://just-eat.co.uk/area/*", "https://www.just-eat.co.uk/area/*", "https://just-eat.co.uk/area/*"],
  	contentStyleFile: [self.data.url("jquery-ui-1.11.4/jquery-ui.min.css"), self.data.url("nomorvom.css")],
     contentScriptOptions: {prefixDataURI: self.data.url("")},
 	contentScriptFile: [self.data.url("jquery-2.1.3/jquery-2.1.3.min.js"), self.data.url("jquery-ui-1.11.4/jquery-ui.min.js"), self.data.url("api.js")],
@@ -27,6 +27,9 @@ function startListening(worker) {
 					//console.log(response.json);
 					if (response.json.establishments.length > 0) {
 						rating = response.json.establishments[0].RatingValue;
+					} 
+					else {
+						rating = -1;
 					}
 				}
 				worker.port.emit("restaurantScore", {id:restaurant.id, rating:rating});


### PR DESCRIPTION
Allows the addon to circumvent any CORS issues or https problems as the request isn't being made by the injected content script code but from the browser itself.

Fixes the bug where users logged into just-eat (which defaults to https) were no longer able to get results.
