### PR TITLE
Fixes to correct #22.

### DIFF
--- a/webextension/addon/nomorvom.css
+++ b/webextension/addon/nomorvom.css
@@ -1,47 +1,49 @@
-#scoreFilterSlider label {
-    position: absolute;
-    width: 20px;
-    font-size: x-small;
-    margin-left: -10px;
-    text-align: center;
-    margin-top: 15px;
-    margin-bottom: 20px;
+#nov-cfg {
 }
 
-#scoreFilterSlider {
-    width: 70%;
-    margin: auto;
-}
+    #nov-cfg .nov-cfg-inner {
+        padding: 4px 10px 0px 10px;
+        border: thin dashed red;
+        background-color: #FFEBE6;
+        font-weight: bold;
+        font-size: small;
+    }
 
-.ui-slider-range { background: red; }
+    #nov-cfg p {
+        line-height: 1.8em;
+        margin-bottom: 6px;
+    }
 
-#nomorvom_config_title {
-    margin-bottom: 10px;
-}
+    #nov-cfg .ui-slider {
+        width: 70%;
+        margin: auto;
+    }
 
-#nomorvom_config_excludeNoData {
-    margin-top: 20px;
-}
+    #nov-cfg .ui-slider-range {
+        background: red;
+    }
 
-#nomorvom_config_excludeNoData_checkbox {
-    margin-left: 10px;
-}
+    #nov-cfg .nov-cfg-filter-labels {
+        overflow: auto;
+        display: block;
+        padding-left: 14.5%;
+    }
 
-#nomorvom_hygieneScore {
-    font-weight: bold;
-    margin: 0px 5px;
-}
+        #nov-cfg .nov-cfg-filter-labels label {
+            float: left;
+            width: 16.5%;
+            font-size: x-small;
+            margin-left: 0px;
+            margin-top: 8px;
+            margin-bottom: 2px;
+        }
 
-#nomorvom_config {
-    border: thin dashed red;
-    background-color: #FFEBE6;
-    font-weight: bold;
-    font-size: small;
-    padding: 5px 10px 5px 10px;
-    margin: 5px;
-}
+    #nov-cfg .nov-cfg-exclude input {
+        margin-left: 6px;
+        margin-top: 8px;
+    }
 
-#nomorvom {
+.nov-score {
     border: thin dashed red;
     background-color: #FFEBE6;
     font-size: small;
@@ -50,12 +52,33 @@
     width: 235px;
 }
 
-#nomorvom_loading {
-    font-weight: bold;
-    padding: 0px 5px;
+    .nov-score .nov-je {
+    }
+
+    .nov-score .nov-loading {
+        font-weight: bold;
+        padding: 0px 5px;
+    }
+
+    .nov-score .nov-progress {
+        width: 220px;
+        height: 30px;
+    }
+
+    .nov-score .nov-rating {
+        font-weight: bold;
+        margin: 0px 5px;
+    }
+
+/* Just eat styles */
+.nov-cfg-je {
+    padding: 16px 0;
 }
 
-#nomorvom_progressbar {
-    width: 220px;
-    height: 30px;
+.nov-cfg-hh {
+    margin: 5px;
+    padding: 5px 10px 5px 10px;
 }
+
+/* Hungry House styles */
+


### PR DESCRIPTION
Addresses styling issues in #22 . The changes look bigger than they actually are - most of it was just tweaking the create config section to use a slightly different structure (+playing with ES6 a bit) and then updating selectors. But VS kept reformatting the code every time I touched something, a battle I lost in places, hence the diff being bigger than it should be.

I've not tested this in FF yet so it may not be ready to go.

Changes:
- JE: Fixed styling of the config box.
- JE: Adjusted restaurant selector to ignore offline venues as these do not have an address.
- Differentiated between styles that control NomOrVom owned elements and styles that integrate these elements into each site.
- Using classes over ID's for elements that appear more than once. Adjusted selection mechanism to reflect this.
- Using an explicit hierarchy in the CSS to make it easier to see the element structure.
- Tweaked the slider label layout approach to avoid the need to hack margins of following elements.
- Using a different event for the slider that fires after the value changes to avoid having to pass in the explicit eventargs from slider.
- Any formatting changes are the result of VS just sticking its nose in and auto formatting everything I touch, sorry.
